### PR TITLE
Remove architectures stanza

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,8 +16,6 @@ description: |
 grade: stable
 confinement: classic
 
-architectures: [s390x, ppc64el, arm64, armhf, amd64, i386]
-
 apps:
   gradle:
     command: opt/gradle/bin/gradle


### PR DESCRIPTION
No need to specify architectures if building for them all.