### PR TITLE
Changed JAVA_HOME to target included JDK.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ apps:
       LANG: C.UTF-8
       LANGUAGE: C.UTF-8
       LC_ALL: C.UTF-8
-      JAVA_HOME: $SNAP/usr/lib/jvm/default-java
+      JAVA_HOME: $SNAP/usr/lib/jvm/java-1.16.0-openjdk-amd64
       GRADLE_USER_HOME: /home/$USER/.gradle
 
 parts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ apps:
       LANG: C.UTF-8
       LANGUAGE: C.UTF-8
       LC_ALL: C.UTF-8
-      JAVA_HOME: $SNAP/usr/lib/jvm/java-1.16.0-openjdk-amd64
+      JAVA_HOME: $SNAP/usr/lib/jvm/java-1.16.0-openjdk-$SNAP_ARCH
       GRADLE_USER_HOME: /home/$USER/.gradle
 
 parts:


### PR DESCRIPTION
Causing an error: 
```
ERROR: JAVA_HOME is set to an invalid directory: /snap/gradle/120/usr/lib/jvm/default-java

Please set the JAVA_HOME variable in your environment to match the
location of your Java installation.
````