### PR TITLE
chore: update gradle to 8.12.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,7 +47,7 @@ parts:
   gradle:
     after: [java]
     plugin: nil
-    source: https://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+    source: https://services.gradle.org/distributions/gradle-8.12.1-bin.zip
     override-build: |
       version=$($SNAPCRAFT_PART_SRC/gradle-*/bin/gradle -qv|awk '/Gradle/{print $2}')
 


### PR DESCRIPTION
This PR updates the downloaded version of gradle to 8.12.1:

https://github.com/gradle/gradle/releases/tag/v8.12.1
