### PR TITLE
chore: bump gradle version to 8.13

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,7 +47,7 @@ parts:
   gradle:
     after: [java]
     plugin: nil
-    source: https://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+    source: https://services.gradle.org/distributions/gradle-8.13-bin.zip
     override-build: |
       version=$($SNAPCRAFT_PART_SRC/gradle-*/bin/gradle -qv|awk '/Gradle/{print $2}')
 


### PR DESCRIPTION
This updates the gradle version to the latest released 8.13. 


